### PR TITLE
perf(db): migrate to SQLite FTS5 for scalable search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --- Dependencies (For Daemon Only) ---
 set(SQLITECPP_INTERNAL_SQLITE ON CACHE BOOL "" FORCE)
+add_compile_definitions(SQLITE_ENABLE_FTS5)
+
 include(FetchContent)
 FetchContent_Declare(SQLiteCpp GIT_REPOSITORY https://github.com/SRombauts/SQLiteCpp.git GIT_TAG 3.3.1)
 FetchContent_MakeAvailable(SQLiteCpp)


### PR DESCRIPTION
Replaces the O(N) `LIKE '%query%'` full-table scan with an O(log N) SQLite FTS5 (Full-Text Search) implementation to ensure low latency as history grows.

Changes:
- build: enforce `SQLITE_ENABLE_FTS5` in CMake via `add_compile_definitions` to ensure the module is compiled into the static library.
- db: bump schema version to v2 and implement migration logic.
- db: create `commands_fts` virtual table using the "External Content" pattern (linked to `commands` table) to minimize storage overhead.
- db: add SQL trigger (`commands_ai`) to automatically sync new insertions to the index.
- db: refactor `HistoryDB::search` to use the `MATCH` operator with prefix sanitization.