### PR TITLE
fix: daemon-side fallback for branch scopeFix branch scope fallback

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -112,22 +112,17 @@ int main(int argc, char* argv[]) {
 
                 SearchScope scope = SearchScope::GLOBAL;
                 if (scope_str == "dir") scope = SearchScope::DIRECTORY;
-                
+
                 if (scope_str == "branch") {
-                    scope = SearchScope::BRANCH;
-                    
-                    // 1. Resolve branch from CWD
                     auto branch_opt = get_git_branch(ctx_val);
-                    
                     if (branch_opt) {
+                        scope = SearchScope::BRANCH;
                         ctx_val = *branch_opt;
-                        // --- PROTOCOL CHANGE ---
-                        // Send the resolved branch name back to the client
-                        // so the UI can display "BSH: Branch (main)"
                         response += "##BRANCH:" + ctx_val + "\n";
-                    } else {
-                        ctx_val = "";
-                        response += "##BRANCH:unknown\n";
+                    } 
+                    else {
+                        scope = SearchScope::DIRECTORY;
+                        response += "##SCOPE:DIRECTORY\n";
                     }
                 }
 


### PR DESCRIPTION
Fixes #2 

This change moves branch-scope fallback handling into the daemon.

When a branch scope is requested in a non-git directory, the daemon now
falls back to DIRECTORY scope instead of returning an unknown branch.
This avoids recursive shell re-execution and unnecessary IPC overhead.

The scope decision is now centralized in the daemon, keeping the client
logic simple and preventing double execution.